### PR TITLE
refactor: default to CID v1 and encode with base32

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "Alan Shaw",
   "license": "MIT",
   "dependencies": {
-    "cids": "github:ipld/js-cid#refactor/cidv1base32-default",
+    "cids": "github:multiformats/js-cid#refactor/cidv1base32-default",
     "explain-error": "^1.0.4",
     "multibase": "~0.6.0",
     "multihashes": "~0.4.14",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "Alan Shaw",
   "license": "MIT",
   "dependencies": {
-    "cids": "~0.5.6",
+    "cids": "github:ipld/js-cid#refactor/cidv1base32-default",
     "explain-error": "^1.0.4",
     "multibase": "~0.6.0",
     "multihashes": "~0.4.14",


### PR DESCRIPTION
Depends on:

* [ ] https://github.com/multiformats/js-cid/pull/73