### PR TITLE
feat: support pipe multiple newline delimited CIDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,14 @@
     "explain-error": "^1.0.4",
     "multibase": "~0.6.0",
     "multihashes": "~0.4.14",
-    "yargs": "^13.2.2"
+    "split2": "^3.1.1",
+    "yargs": "^15.0.2"
   },
   "devDependencies": {
-    "aegir": "^18.2.2",
+    "aegir": "^20.4.1",
     "chai": "^4.1.2",
     "dirty-chai": "^2.0.1",
-    "execa": "^1.0.0"
+    "execa": "^3.4.0"
   },
   "contributors": [
     "Alan Shaw <alan.shaw@protocol.ai>",

--- a/src/cli/commands/base32.js
+++ b/src/cli/commands/base32.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const split = require('split2')
 const CIDTool = require('../../')
 
 module.exports = {
@@ -12,9 +13,9 @@ module.exports = {
       return argv.cids.forEach(cid => console.log(CIDTool.base32(cid)))
     }
 
-    process.stdin.on('data', data => {
+    process.stdin.pipe(split()).on('data', data => {
       const cid = data.toString().trim()
-      console.log(CIDTool.base32(cid))
+      if (cid) console.log(CIDTool.base32(cid))
     })
   }
 }

--- a/src/cli/commands/format.js
+++ b/src/cli/commands/format.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const split = require('split2')
 const CIDTool = require('../../')
 
 module.exports = {
@@ -57,9 +58,9 @@ module.exports = {
       return argv.cids.forEach(cid => console.log(CIDTool.format(cid, options)))
     }
 
-    process.stdin.on('data', data => {
+    process.stdin.pipe(split()).on('data', data => {
       const cid = data.toString().trim()
-      console.log(CIDTool.format(cid, options))
+      if (cid) console.log(CIDTool.format(cid, options))
     })
   }
 }

--- a/test/cli/base32.spec.js
+++ b/test/cli/base32.spec.js
@@ -28,4 +28,15 @@ describe('cli base32', () => {
 
     throw new Error('did no fail on invalid CID')
   })
+
+  it('should support piping multiple newline delimited CIDs to converter', async () => {
+    const cli = CIDToolCli()
+    const input = Object.keys(TestCID).map(k => TestCID[k])
+    const expectedOutput = input.map(() => TestCID.b32).join('\n') + '\n'
+    const proc = cli('base32')
+    input.forEach(cid => proc.stdin.write(`${cid}\n`))
+    proc.stdin.end()
+    const { stdout } = await proc
+    expect(stdout).to.equal(expectedOutput)
+  })
 })

--- a/test/cli/format.spec.js
+++ b/test/cli/format.spec.js
@@ -29,4 +29,15 @@ describe('cli format', () => {
     const { stdout } = await cli(`format ${TestCID.v0} --cid-version=1 --base=base32`)
     expect(stdout).to.equal(expectedOutput)
   })
+
+  it('should support piping multiple newline delimited CIDs to formatter', async () => {
+    const cli = CIDToolCli()
+    const input = Object.keys(TestCID).map(k => TestCID[k])
+    const expectedOutput = input.map(() => TestCID.b32).join('\n') + '\n'
+    const proc = cli('format --cid-version=1 --base=base32')
+    input.forEach(cid => proc.stdin.write(`${cid}\n`))
+    proc.stdin.end()
+    const { stdout } = await proc
+    expect(stdout).to.equal(expectedOutput)
+  })
 })

--- a/test/cli/utils/cid-tool-cli.js
+++ b/test/cli/utils/cid-tool-cli.js
@@ -6,7 +6,7 @@ const binPath = path.join(process.cwd(), 'src', 'cli', 'bin.js')
 
 module.exports = options => {
   const config = Object.assign({}, {
-    stripEof: false,
+    stripFinalNewline: false,
     env: Object.assign({}, process.env),
     timeout: 60 * 1000
   }, options)


### PR DESCRIPTION
Allows the user to pipe a file of newline delimited CIDs to the `base32` or `format` command instead of invoking it for each or passing them all as parameters.

The motivation for this originally was to fix an issue where the following command throws an error because the input has a trailing newline:

```console
$ jsipfs id | json id | jsipfs cid base32
bafybeidta3hkxk3ihxfsk765oswgsjhmvcnkeestyuov6r2t5tyts4xuoe
Error: invalid cid: 
    at Object.base32 (/Users/alan/.iim/dists/js-ipfs@0.40.0-rc.0/node_modules/cid-tool/src/core/base32.js:10:11)
  Error: multihash too short. must be > 3 bytes.
    at Function.validateCID (/Users/alan/.iim/dists/js-ipfs@0.40.0-rc.0/node_modules/cids/src/index.js:286:13)
    at new CID (/Users/alan/.iim/dists/js-ipfs@0.40.0-rc.0/node_modules/cids/src/index.js:91:11)
    at new CID (/Users/alan/.iim/dists/js-ipfs@0.40.0-rc.0/node_modules/class-is/index.js:15:17)
    at Object.base32 (/Users/alan/.iim/dists/js-ipfs@0.40.0-rc.0/node_modules/cid-tool/src/core/base32.js:8:11)
    at Socket.<anonymous> (/Users/alan/.iim/dists/js-ipfs@0.40.0-rc.0/node_modules/cid-tool/src/cli/commands/base32.js:17:27)
    at Socket.emit (events.js:210:5)
    at addChunk (_stream_readable.js:326:12)
    at readableAddChunk (_stream_readable.js:301:11)
    at Socket.Readable.push (_stream_readable.js:235:10)
    at Pipe.onStreamRead (internal/stream_base_commons.js:182:23)
```

Newline delimited data (like ndjson for example) usually ignores a trailing newline so we do the same here, fixing the error but allowing us to easily support multiple CIDs being piped.

I want to add this command in an example for the [js-ipfs 0.40](https://github.com/ipfs/js-ipfs/issues/2558) release to show how people could convert their Peer ID to a base32 CID for use in IPNS paths.