### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,18 +28,18 @@
   "author": "Alan Shaw",
   "license": "MIT",
   "dependencies": {
-    "cids": "~0.7.0",
+    "cids": "~0.8.0",
     "explain-error": "^1.0.4",
-    "multibase": "~0.6.0",
+    "multibase": "~0.7.0",
     "multihashes": "~0.4.14",
     "split2": "^3.1.1",
     "yargs": "^15.0.2"
   },
   "devDependencies": {
-    "aegir": "^20.4.1",
+    "aegir": "^21.10.2",
     "chai": "^4.1.2",
     "dirty-chai": "^2.0.1",
-    "execa": "^3.4.0"
+    "execa": "^4.0.0"
   },
   "contributors": [
     "Alan Shaw <alan.shaw@protocol.ai>",

--- a/src/core/codecs.js
+++ b/src/core/codecs.js
@@ -4,7 +4,6 @@ const CID = require('cids')
 
 module.exports = function codecs () {
   return Object.keys(CID.codecs).map(name => {
-    const code = parseInt(CID.codecs[name].toString('hex'), 16)
-    return { name, code }
+    return { name, code: CID.codecs[name] }
   })
 }

--- a/test/cli/codecs.spec.js
+++ b/test/cli/codecs.spec.js
@@ -20,7 +20,7 @@ describe('cli codecs', () => {
     const cli = CIDToolCli()
     const expectedOutput = Object.keys(CID.codecs)
       .map(name => {
-        const code = parseInt(CID.codecs[name].toString('hex'), 16)
+        const code = CID.codecs[name]
         return `${code} ${name}`
       })
       .join('\n') + '\n'

--- a/test/core/codecs.spec.js
+++ b/test/core/codecs.spec.js
@@ -15,7 +15,7 @@ describe('core codecs', () => {
     expect(Object.keys(CID.codecs).every(name => {
       return codecs.find(c => {
         return c.name === name &&
-          c.code === parseInt(CID.codecs[name].toString('hex'), 16)
+          c.code === CID.codecs[name]
       })
     })).to.be.true()
   })


### PR DESCRIPTION
removed codec code encoding to hex because identity can't be encoded in hex and failed