### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Convert the passed CID to base 32 CID version 1.
 
 | Name | Type | Description |
 |------|------|-------------|
-| cid | [`CID`](https://github.com/ipld/js-cid/)\|`String`\|`Buffer` | CID to convert. |
+| cid | [`CID`](https://github.com/ipld/js-cid/)\|`String`\|`Uint8Array` | CID to convert. |
 
 #### Returns
 
@@ -185,7 +185,7 @@ Format and convert a CID in various useful ways.
 
 | Name | Type | Description |
 |------|------|-------------|
-| cid | [`CID`](https://github.com/ipld/js-cid/)\|`String`\|`Buffer` | CID to format |
+| cid | [`CID`](https://github.com/ipld/js-cid/)\|`String`\|`Uint8Array` | CID to format |
 | options | `Object` | (optional) options for formatting |
 | options.format | `String` | Format string to use, default "%s" |
 | options.base | `String` | Multibase name or code to use for output |

--- a/package.json
+++ b/package.json
@@ -28,17 +28,16 @@
   "author": "Alan Shaw",
   "license": "MIT",
   "dependencies": {
-    "cids": "~0.8.0",
+    "cids": "^1.0.0",
     "explain-error": "^1.0.4",
-    "multibase": "~0.7.0",
-    "multihashes": "~0.4.14",
+    "multibase": "^3.0.0",
+    "multihashes": "^3.0.1",
     "split2": "^3.1.1",
+    "uint8arrays": "^1.1.0",
     "yargs": "^15.0.2"
   },
   "devDependencies": {
-    "aegir": "^21.10.2",
-    "chai": "^4.1.2",
-    "dirty-chai": "^2.0.1",
+    "aegir": "^25.1.0",
     "execa": "^4.0.0"
   },
   "contributors": [

--- a/src/cli/commands/bases.js
+++ b/src/cli/commands/bases.js
@@ -23,11 +23,11 @@ module.exports = {
   handler (argv) {
     CIDTool.bases().forEach(({ name, code }) => {
       if (argv.prefix && argv.numeric) {
-        console.log(`${code} ${code.charCodeAt(0)} ${name}`) // eslint-disable-line no-console
+        console.log(`${code}\t${code.charCodeAt(0)}\t${name}`) // eslint-disable-line no-console
       } else if (argv.prefix) {
-        console.log(`${code} ${name}`) // eslint-disable-line no-console
+        console.log(`${code}\t${name}`) // eslint-disable-line no-console
       } else if (argv.numeric) {
-        console.log(`${code.charCodeAt(0)} ${name}`) // eslint-disable-line no-console
+        console.log(`${code.charCodeAt(0)}\t${name}`) // eslint-disable-line no-console
       } else {
         console.log(name) // eslint-disable-line no-console
       }

--- a/src/cli/commands/codecs.js
+++ b/src/cli/commands/codecs.js
@@ -18,7 +18,7 @@ module.exports = {
   handler (argv) {
     CIDTool.codecs().forEach(({ name, code }) => {
       if (argv.numeric) {
-        console.log(`${code} ${name}`) // eslint-disable-line no-console
+        console.log(`${code}\t${name}`) // eslint-disable-line no-console
       } else {
         console.log(name) // eslint-disable-line no-console
       }

--- a/src/core/bases.js
+++ b/src/core/bases.js
@@ -3,8 +3,9 @@
 const multibase = require('multibase')
 
 module.exports = function bases () {
-  return multibase.names.map((name, i) => {
-    const code = multibase.codes[i]
-    return { name, code }
+  return Object.keys(multibase.names).map(name => {
+    const base = multibase.names[name]
+
+    return { name: base.name, code: base.code }
   })
 }

--- a/src/core/format.js
+++ b/src/core/format.js
@@ -6,6 +6,7 @@ const codecs = require('./codecs')
 const explain = require('explain-error')
 const multibase = require('multibase')
 const multihash = require('multihashes')
+const uint8ArrayToString = require('uint8arrays/to-string')
 
 module.exports = function format (cid, options) {
   options = options || {}
@@ -87,19 +88,19 @@ function replacer (cid, base, options) {
       case 'L': // hash length
         return multihash.decode(cid.multihash).length
       case 'm': // multihash encoded in base %b
-        return multibase.encode(base, cid.multihash)
+        return uint8ArrayToString(multibase.encode(base, cid.multihash))
       case 'M': // multihash encoded in base %b without base prefix
-        return multibase.encode(base, cid.multihash).slice(1)
+        return uint8ArrayToString(cid.multihash, base)
       case 'd': // hash digest encoded in base %b
-        return multibase.encode(base, multihash.decode(cid.multihash).digest)
+        return uint8ArrayToString(multibase.encode(base, multihash.decode(cid.multihash).digest))
       case 'D': // hash digest encoded in base %b without base prefix
-        return multibase.encode(base, multihash.decode(cid.multihash).digest).slice(1)
+        return uint8ArrayToString(multihash.decode(cid.multihash).digest, base)
       case 's': // cid string encoded in base %b
-        return cid.toBaseEncodedString(base)
+        return cid.toString(base)
       case 'S': // cid string without base prefix
         return cid.version === 1
-          ? cid.toBaseEncodedString(base).slice(1)
-          : multibase.encode(base, cid.buffer).toString().slice(1)
+          ? cid.toString(base).slice(1)
+          : uint8ArrayToString(cid.bytes, base)
       case 'P': // prefix
         return prefix(cid)
       default:

--- a/test/cli/base32.spec.js
+++ b/test/cli/base32.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const CIDToolCli = require('./utils/cid-tool-cli')
 const TestCID = require('../fixtures/test-cid')
 

--- a/test/cli/bases.spec.js
+++ b/test/cli/bases.spec.js
@@ -1,25 +1,23 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const multibase = require('multibase')
 const CIDToolCli = require('./utils/cid-tool-cli')
 
 describe('cli bases', () => {
   it('should list multibase names', async () => {
     const cli = CIDToolCli()
-    const expectedOutput = multibase.names.join('\n') + '\n'
+    const expectedOutput = Object.keys(multibase.names).join('\n') + '\n'
     const { stdout } = await cli('bases')
     expect(stdout).to.equal(expectedOutput)
   })
 
   it('should list multibase codes and names', async () => {
     const cli = CIDToolCli()
-    const expectedOutput = multibase.names
-      .map((name, i) => `${multibase.codes[i]} ${name}`)
+    const expectedOutput = Object.keys(multibase.names)
+      .map(name => multibase.names[name])
+      .map(base => `${base.code}\t${base.name}`)
       .join('\n') + '\n'
     const { stdout } = await cli('bases --prefix')
     expect(stdout).to.equal(expectedOutput)
@@ -27,8 +25,9 @@ describe('cli bases', () => {
 
   it('should list multibase numeric codes and names', async () => {
     const cli = CIDToolCli()
-    const expectedOutput = multibase.names
-      .map((name, i) => `${multibase.codes[i].charCodeAt(0)} ${name}`)
+    const expectedOutput = Object.keys(multibase.names)
+      .map(name => multibase.names[name])
+      .map(base => `${base.code.charCodeAt(0)}\t${base.name}`)
       .join('\n') + '\n'
     const { stdout } = await cli('bases --numeric')
     expect(stdout).to.equal(expectedOutput)
@@ -36,8 +35,9 @@ describe('cli bases', () => {
 
   it('should list multibase codes, numeric codes and names', async () => {
     const cli = CIDToolCli()
-    const expectedOutput = multibase.names
-      .map((name, i) => `${multibase.codes[i]} ${multibase.codes[i].charCodeAt(0)} ${name}`)
+    const expectedOutput = Object.keys(multibase.names)
+      .map(name => multibase.names[name])
+      .map(base => `${base.code}\t${base.code.charCodeAt(0)}\t${base.name}`)
       .join('\n') + '\n'
     const { stdout } = await cli('bases --prefix --numeric')
     expect(stdout).to.equal(expectedOutput)

--- a/test/cli/codecs.spec.js
+++ b/test/cli/codecs.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const CID = require('cids')
 const CIDToolCli = require('./utils/cid-tool-cli')
 
@@ -21,7 +18,7 @@ describe('cli codecs', () => {
     const expectedOutput = Object.keys(CID.codecs)
       .map(name => {
         const code = CID.codecs[name]
-        return `${code} ${name}`
+        return `${code}\t${name}`
       })
       .join('\n') + '\n'
     const { stdout } = await cli('codecs --numeric')

--- a/test/cli/format.spec.js
+++ b/test/cli/format.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const CIDToolCli = require('./utils/cid-tool-cli')
 const TestCID = require('../fixtures/test-cid')
 

--- a/test/cli/hashes.spec.js
+++ b/test/cli/hashes.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const multihash = require('multihashes')
 const CIDToolCli = require('./utils/cid-tool-cli')
 

--- a/test/core/base32.spec.js
+++ b/test/core/base32.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const CID = require('cids')
 const CIDTool = require('../../')
 const TestCID = require('../fixtures/test-cid')
@@ -14,16 +11,16 @@ describe('core base32', () => {
     const inputs = [
       TestCID.v0,
       new CID(TestCID.v0),
-      new CID(TestCID.v0).buffer,
+      new CID(TestCID.v0).bytes,
       TestCID.b32,
       new CID(TestCID.b32),
-      new CID(TestCID.b32).buffer,
+      new CID(TestCID.b32).bytes,
       TestCID.b58,
       new CID(TestCID.b58),
-      new CID(TestCID.b58).buffer,
+      new CID(TestCID.b58).bytes,
       TestCID.b64,
       new CID(TestCID.b64),
-      new CID(TestCID.b64).buffer
+      new CID(TestCID.b64).bytes
     ]
 
     inputs.forEach(input => {

--- a/test/core/bases.spec.js
+++ b/test/core/bases.spec.js
@@ -1,17 +1,14 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const multibase = require('multibase')
 const CIDTool = require('../../')
 
 describe('core bases', () => {
   it('should return list of multibase names and codes', () => {
     const bases = CIDTool.bases()
-    expect(multibase.names.every(name => bases.find(b => b.name === name)))
+    expect(Object.keys(multibase.names).every(name => bases.find(b => b.name === name)))
       .to.be.true()
   })
 })

--- a/test/core/codecs.spec.js
+++ b/test/core/codecs.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const CID = require('cids')
 const CIDTool = require('../../')
 

--- a/test/core/format.spec.js
+++ b/test/core/format.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const CID = require('cids')
 const CIDTool = require('../../')
 

--- a/test/core/hashes.spec.js
+++ b/test/core/hashes.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const multihash = require('multihashes')
 const CIDTool = require('../../')
 


### PR DESCRIPTION
BREAKING CHANGES:

- All use of node Buffers have been replaced with Uint8Arrays
- All deps of this module now use Uint8Arrays in place of Buffers